### PR TITLE
Main.rs update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,27 +11,50 @@ pub mod cursor ;
 pub mod clap ;
 mod grid ;
 pub mod frame ;
+
 //
 use conrod::{Canvas, Theme, Widget, color};
-use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings, clear};
 //
 
 pub use common::{ Dir, Evolution, Seed } ;
 pub use grid::{ Cell, Grid } ;
 
-//
+/*
+// Will be needed for game implementation
 type Backend = (<piston_window::G2d<'static> as conrod::Graphics>::Texture, Glyphs);
 type Ui = conrod::Ui<Backend>;
 type UiCell<'a> = conrod::UiCell<'a, Backend>;
 //
+*/
 
 /// Entry point.
 fn main() {
-  /*/HERE 
+ 
+
+ /*
+  // test code 1.0 gets ready to build a window but doesn't draw it 
   let window: PistonWindow =
         WindowSettings::new("Canvas Demo", [800, 600])
-            .exit_on_esc(true).vsync(true).build().unwrap();
-  //TO HERE*/
+            .exit_on_esc(true)
+            .vsync(true)
+            .build()
+            .unwrap();
+ */
+
+    // ***THIS ONE WORKS***
+    // Construct the window.
+    // Creates a new window and draws the border
+  let window: PistonWindow = WindowSettings::new("2048", (640, 480))
+    .exit_on_esc(true)
+    .build()
+    .unwrap_or_else(|e| { panic!("Failed to build PistonWindow: {}", e) });
+  for e in window {
+    e.draw_2d(|_c, g| {
+      clear([0.5, 1.0, 0.5, 1.0], g);
+    });
+  }
+
   use std::process::exit ;
 
   // Getting seed and painter from command line arguments.
@@ -44,5 +67,5 @@ fn main() {
   } ;
 
   frame::rendering_loop_user(seed, painter)
-}
 
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! Textual version of the game 2048.
+//! Textual version of the game 2048. Update Jon
 
 extern crate ansi_term as ansi ;
 extern crate rand ;


### PR DESCRIPTION
## 2048 update

I made a window pop up on the screen using the following code from: [PistonDevelopers/piston_window](https://github.com/PistonDevelopers/piston_window)

updating main.rs using the following code: 

```
extern crate piston_window;

/// use piston_window::*; doesn't seem to work 
/// bug figure out the syntax for using complete libraries
use piston_window::{blah, blah, blah};
fn main() {
    let window: PistonWindow = WindowSettings::new("2048", (640, 480))
        .exit_on_esc(true)
        .build()
        .unwrap_or_else(|e| { panic!("Failed to build PistonWindow: {}", e) });
    for e in window {
        e.draw_2d(|_c, g| {
            clear([0.5, 1.0, 0.5, 1.0], g);
        });
    }
}
```

I had an error with the clear function and had to edit the use piston_window also within main.rs:

```
use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings, clear};
```
